### PR TITLE
broken: middleware nextjs support

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,7 @@ export default [
       globals: {
         ...globals.node,
         ...globals.es2021,
+        BufferEncoding: 'readonly',
       },
     },
     plugins: {

--- a/src/evaluation/code_executor.ts
+++ b/src/evaluation/code_executor.ts
@@ -1,10 +1,9 @@
 import { fork } from 'child_process';
-import { join } from 'path';
 import type { EvaluatedModuleResult, EvaluationRequest } from '../core';
 
 export async function executeIsolated(request: EvaluationRequest): Promise<EvaluatedModuleResult> {
   return new Promise(resolve => {
-    const workerPath = join(__dirname, 'eval_worker.ts');
+    const workerPath = require.resolve('./eval_worker');
 
     const child = fork(workerPath, { silent: true });
 

--- a/src/http/security.ts
+++ b/src/http/security.ts
@@ -1,8 +1,24 @@
 import type { Request, Response, TidewaveConfig } from './index';
 
+function fetchRemoteIp(req: Request): string | null {
+  const remote = req.socket.remoteAddress;
+
+  if (remote) return remote;
+
+  const ip = (req.headers['x-real-ip'] && req.headers['x-forwarded-for']) || null;
+
+  if (Array.isArray(ip)) {
+    return ip.join();
+  }
+
+  return ip;
+}
+
 export function checkRemoteIp(req: Request, res: Response, config: TidewaveConfig): boolean {
-  const { remoteAddress } = req.socket;
-  if (isLocalIp(remoteAddress)) return true;
+  const ip = fetchRemoteIp(req);
+
+  if (!ip) return false;
+  if (isLocalIp(ip)) return true;
   if (config.allowRemoteAccess) return true;
 
   const message =

--- a/src/next-js.ts
+++ b/src/next-js.ts
@@ -1,14 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { NextResponse, type NextRequest } from 'next/server';
 import {
   checkSecurity,
   methodNotAllowed,
   type TidewaveConfig,
   type Request,
   type Response,
+  ENDPOINT,
 } from './http';
 import { handleMcp } from './http/handlers/mcp';
 import { handleShell } from './http/handlers/shell';
 import bodyParser from 'body-parser';
+import { IncomingMessage, ServerResponse } from 'http';
+import { Socket } from 'net';
 
 const DEFAULT_CONFIG: TidewaveConfig = {
   allowRemoteAccess: false,
@@ -18,6 +22,7 @@ const DEFAULT_CONFIG: TidewaveConfig = {
 };
 
 type NextJsHandler = (_req: NextApiRequest, _res: NextApiResponse) => Promise<void>;
+type NextJsMiddleware = (_req: NextRequest) => Promise<NextResponse>;
 
 type NextHandler = () => ValueOrPromise<unknown>;
 
@@ -68,5 +73,149 @@ export function toNodeHandler(config: TidewaveConfig = DEFAULT_CONFIG): NextJsHa
     if (endpoint === 'shell') return connectWrapper(handleShell)(req, res, next);
 
     return res.status(404).json({ message: `Route not found: ${req.method} ${req.url}` });
+  };
+}
+
+async function requestAdapter(next: NextRequest): Promise<Request> {
+  const req: Request = new IncomingMessage(new Socket());
+  const body = (await next.json()) as Record<string, unknown>;
+  req.method = next.method;
+  req.body = body;
+  req.url = next.url;
+  req.headers = Object.fromEntries(next.headers);
+  return req;
+}
+
+function nextMethodNotAllowed(): NextResponse {
+  return NextResponse.json(
+    { message: 'method not allowed' },
+    {
+      headers: [['Allow', 'POST']],
+      status: 405,
+    },
+  );
+}
+
+interface ResponseData {
+  body: Buffer;
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+type StreamCallback = (_err: Error | null | undefined) => void;
+
+function captureResponse(res: ServerResponse): Promise<ResponseData> {
+  return new Promise(resolve => {
+    const chunks: Buffer[] = [];
+
+    const respdata: ResponseData = {
+      body: Buffer.alloc(0),
+      statusCode: 200,
+      headers: {},
+    };
+
+    const originalSetHeader = res.setHeader.bind(res);
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    res.write = (chunk: any, encoding, cb?: StreamCallback): boolean => {
+      if (Buffer.isBuffer(chunk)) {
+        chunks.push(chunk);
+      } else if (typeof chunk === 'string') {
+        const enc = typeof encoding === 'string' ? encoding : 'utf8';
+        chunks.push(Buffer.from(chunk, enc));
+      }
+
+      if (typeof cb === 'function') {
+        process.nextTick(cb);
+      } else if (typeof encoding === 'function') {
+        process.nextTick(encoding);
+      }
+
+      return true;
+    };
+
+    res.end = (
+      chunk?: any /* eslint-disable-line @typescript-eslint/no-explicit-any */,
+      encoding?: BufferEncoding | StreamCallback,
+      cb?: StreamCallback,
+    ): ServerResponse => {
+      if (chunk) {
+        if (Buffer.isBuffer(chunk)) {
+          chunks.push(chunk);
+        } else if (typeof chunk === 'string') {
+          const enc = typeof encoding === 'string' ? encoding : 'utf8';
+          chunks.push(Buffer.from(chunk, enc));
+        }
+      }
+
+      respdata.statusCode = res.statusCode;
+
+      if (res.getHeaders) {
+        const responseHeaders = res.getHeaders();
+        respdata.headers = Object.fromEntries(
+          Object.entries(responseHeaders).map(([key, value]) => [
+            key.toLowerCase(),
+            Array.isArray(value) ? value.join(', ') : String(value),
+          ]),
+        );
+      }
+
+      respdata.body = Buffer.concat(chunks);
+
+      // Handle callbacks
+      if (typeof cb === 'function') {
+        process.nextTick(cb);
+      } else if (typeof encoding === 'function') {
+        process.nextTick(encoding);
+      }
+
+      resolve(respdata);
+      return res;
+    };
+
+    res.setHeader = (name: string, value: string | string[] | number): ServerResponse => {
+      respdata.headers[name.toLowerCase()] = Array.isArray(value)
+        ? value.join(', ')
+        : String(value);
+      return originalSetHeader(name, value);
+    };
+  });
+}
+
+export function toNextMiddleware(config: TidewaveConfig): NextJsMiddleware {
+  return async function middleware(req: NextRequest): Promise<NextResponse> {
+    const next: () => void = () => {};
+
+    if (req.method !== 'POST') return nextMethodNotAllowed();
+
+    const msg = await requestAdapter(req);
+    const res = new ServerResponse(msg);
+
+    const securityMiddleware = checkSecurity(config);
+    await connectWrapper(securityMiddleware)(msg, res, next);
+
+    const responsePromise = captureResponse(res);
+
+    if (req.nextUrl.pathname === `${ENDPOINT}/mcp`) {
+      await connectWrapper(handleMcp)(msg, res, next);
+      const responseData = await responsePromise;
+      return new NextResponse(responseData.body.toString(), {
+        status: responseData.statusCode,
+        headers: responseData.headers,
+      });
+    }
+
+    if (req.nextUrl.pathname === `${ENDPOINT}/shell`) {
+      console.log('Ih, passou por aqui');
+      await connectWrapper(handleShell)(msg, res, next);
+      const responseData = await responsePromise;
+      console.log('Aqui oh', responseData);
+      return new NextResponse(responseData.body.toString(), {
+        status: responseData.statusCode,
+        headers: responseData.headers,
+      });
+    }
+
+    return NextResponse.json({ message: `Route not found: ${req.method} ${req.nextUrl.pathname}` });
   };
 }


### PR DESCRIPTION
im opening this pr to share the implemented part until now.

so, supporting `middleware.ts` have some cons/blocks, even on node.js runtime (Next.Js v15.5+):
1. the request object that we receive is the web `Request` class, which per si is very limited, being incompatible with Node.js request `IncomingMessage`
1. the reponse object is also the `Response` web class, which i found impossible to adapt/convert from a Node `ServerResponse<IncomingMessage>`
1. `middleware.ts` with node.js runtime is only available on the latest major/minor version of next.js which considering the above points, seems to be also another block


on this pr i successfully converted between `Request` -> `IncomingMessage` without losing context/data, however the convertion between `ServerResponse<IncomingMessage>` to `NextResponse` seems somehting impractical

given that, and also taking in account that the initial implementation on #18 requires the `/api` prefix on routes (pages routes requirement)

i think out last resource would be to try the app router approach, which allows us to hook in the `/` root of server, however we still receive a `Request`/`Resposne` web objects

in that case, since the MCP sdk also relies on the nodejs `IncomingMessage` type, i can think on:
1. for `/shell`, we can write a ReadableStream directly, basically rewriting the handler specifically for next.js, easier
2. for `/mcp` we could try to do the same, but i'm unsure if it would work, another option would be create a wrapper mcp transport that handles the web request/response objects?

wow, everything seems 🤯
