### PR TITLE
Simplify middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ bun add --dev tidewave
 
 Then, configure it:
 
-Create `pages/api/tidewave/[...all].ts` with:
+Create `pages/api/tidewave.ts` with:
 
 ```typescript
 import type { NextApiRequest, NextApiResponse } from 'next';
@@ -128,14 +128,8 @@ Then create (or modify) `middleware.ts` with:
 import { NextRequest, NextResponse } from 'next/server';
 
 export function middleware(req: NextRequest): NextResponse {
-  const { pathname } = req.nextUrl;
-
-  if (pathname === '/tidewave') {
-    return NextResponse.rewrite(new URL(`/api/tidewave/index`, req.url));
-  }
-
-  if (pathname.startsWith('/tidewave')) {
-    return NextResponse.rewrite(new URL(`/api${pathname}`, req.url));
+  if (req.nextUrl.pathname.startsWith('/tidewave')) {
+    return NextResponse.rewrite(new URL(`/api/tidewave`, req.url));
   }
 
   // Here you could add your own logic or different middlewares.


### PR DESCRIPTION
See README changes for the simplified instructions.

In the request handler, we look at the original URL (from before middleware rewrite), therefore it doesn't really matter at which path the handler itself resides. This means:

1. Instead of `pages/api/tidewave/[...all].ts`, we can have a simpler route `pages/api/tidewave.ts` and it works the same way. This file is slightly less annoying to create (compared to `[...all]`).

2. The middleware can redirect to a fixed route in all cases, which streamlines the code.

I also added a check to make sure that if someone accesses `/api/tidewave` we show a message to clarify.

I don't see any downsides, WDYT?