### PR TITLE
Updates for Next.js 16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ directory of the project (or inside `src` folder if using one):
 
 ```typescript
 // instrumentation.ts
-// instrumentation.ts
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import type { LogRecordProcessor } from '@opentelemetry/sdk-logs';


### PR DESCRIPTION
* Use proxy.ts on 16+ and later (middleware.ts doesn't work)
* Fix typescript violations in instrumentation.ts
* Fix handler path