### PR TITLE
fix: move CLI dependencies from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "body-parser": "^2.2.0",
     "connect": "^3.7.0",
     "typescript": "^5",
-    "zod": "3.25.76"
+    "zod": "3.25.76",
+    "chalk": "^5.3.0",
+    "commander": "^12.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",
@@ -84,8 +86,6 @@
     "@vercel/otel": "^2.0.1",
     "@vitest/ui": "^3.2.4",
     "bun-types": "latest",
-    "commander": "^12.1.0",
-    "chalk": "^5.3.0",
     "eslint": "^9.16.0",
     "globals": "^15.14.0",
     "next": "^15.5.3",


### PR DESCRIPTION
Moves 'commander' and 'chalk' from devDependencies to dependencies to fix ERR_MODULE_NOT_FOUND errors when running CLI commands via pnpm exec tidewave in consuming projects.

These packages are required at runtime for CLI functionality and should be available when tidewave is installed as a dependency.