### PR TITLE
fix: install missing OpenTelemetry type dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ First install the NodeSDK:
 
 ```sh
 npm install @opentelemetry/sdk-node
+npm install -D @opentelemetry/sdk-trace-base @opentelemetry/sdk-logs
 ```
 
 And then create (or modify) a custom `instrumentation.ts` file in the root

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -128,10 +128,10 @@ async function installDependencies(dir: string, dryRun: boolean): Promise<void> 
 
   const pm = detectPackageManager(dir);
   const devDepCommands: Record<string, string[]> = {
-    npm: ['install', '-D', 'tidewave'],
-    yarn: ['add', '-D', 'tidewave'],
-    pnpm: ['add', '--save-dev', 'tidewave'],
-    bun: ['add', '--dev', 'tidewave'],
+    npm: ['install', '-D', 'tidewave', '@opentelemetry/sdk-trace-base', '@opentelemetry/sdk-logs'],
+    yarn: ['add', '-D', 'tidewave', '@opentelemetry/sdk-trace-base', '@opentelemetry/sdk-logs'],
+    pnpm: ['add', '--save-dev', 'tidewave', '@opentelemetry/sdk-trace-base', '@opentelemetry/sdk-logs'],
+    bun: ['add', '--dev', 'tidewave', '@opentelemetry/sdk-trace-base', '@opentelemetry/sdk-logs'],
   };
 
   const depCommands: Record<string, string[]> = {


### PR DESCRIPTION
Adds @opentelemetry/sdk-trace-base and @opentelemetry/sdk-logs to the devDependencies installed by 'tidewave install' command.

These packages are imported as types in the generated instrumentation.ts:
- import type { SpanProcessor } from '@opentelemetry/sdk-trace-base'
- import type { LogRecordProcessor } from '@opentelemetry/sdk-logs'

While these are transitive dependencies of @opentelemetry/sdk-node, TypeScript cannot resolve their types unless explicitly listed in package.json, especially with strict package managers like pnpm.

Since these are type-only imports, they are installed as devDependencies rather than runtime dependencies.

Fixes #39