### PR TITLE
Fix extractDocs for re-exported (aliased) symbols

### DIFF
--- a/src/resolution/index.ts
+++ b/src/resolution/index.ts
@@ -212,9 +212,10 @@ export async function extractDocs(modulePath: string): Promise<ExtractResult> {
       const exportSymbol = exports.find((exp: ts.Symbol) => exp.getName() === symbol);
 
       if (exportSymbol) {
-        // Check if the export symbol has a meaningful valueDeclaration
-        // OR if it's a type-only symbol like interface/type alias/enum
-        if (
+        // Resolve re-exported (aliased) symbols to their original declaration
+        if (exportSymbol.flags & ts.SymbolFlags.Alias) {
+          targetSymbol = checker.getAliasedSymbol(exportSymbol);
+        } else if (
           exportSymbol.valueDeclaration &&
           (ts.isFunctionDeclaration(exportSymbol.valueDeclaration) ||
             ts.isClassDeclaration(exportSymbol.valueDeclaration) ||

--- a/test/fixtures/reexport-barrel.ts
+++ b/test/fixtures/reexport-barrel.ts
@@ -2,4 +2,5 @@
  * Barrel file that re-exports symbols from reexport-source.
  * Used to test that extractDocs resolves aliased (re-exported) symbols.
  */
-export { add, Counter, Status, Result } from './reexport-source';
+export { add, Counter, Status } from './reexport-source';
+export type { Result } from './reexport-source';

--- a/test/fixtures/reexport-barrel.ts
+++ b/test/fixtures/reexport-barrel.ts
@@ -1,0 +1,5 @@
+/**
+ * Barrel file that re-exports symbols from reexport-source.
+ * Used to test that extractDocs resolves aliased (re-exported) symbols.
+ */
+export { add, Counter, Status, Result } from './reexport-source';

--- a/test/fixtures/reexport-source.ts
+++ b/test/fixtures/reexport-source.ts
@@ -1,0 +1,47 @@
+/**
+ * Adds two numbers together.
+ * @param a - First number
+ * @param b - Second number
+ * @returns The sum of a and b
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+/**
+ * A simple counter class for testing re-exports.
+ */
+export class Counter {
+  private value: number;
+
+  constructor(initial = 0) {
+    this.value = initial;
+  }
+
+  /** Increment and return the new value. */
+  increment(): number {
+    return ++this.value;
+  }
+
+  /** Get the current value. */
+  get current(): number {
+    return this.value;
+  }
+}
+
+/**
+ * Status codes for operations.
+ */
+export enum Status {
+  Ok = 'ok',
+  Error = 'error',
+  Pending = 'pending',
+}
+
+/**
+ * Shape of a result object.
+ */
+export interface Result {
+  status: Status;
+  data: unknown;
+}

--- a/test/resolution.test.ts
+++ b/test/resolution.test.ts
@@ -289,9 +289,7 @@ describe('TypeScript Extraction', () => {
 
   describe('re-exported (aliased) symbols', () => {
     it('should extract docs for a re-exported function', async () => {
-      const docs = (await extractDocs(
-        './test/fixtures/reexport-barrel:add',
-      )) as SymbolInfo;
+      const docs = (await extractDocs('./test/fixtures/reexport-barrel:add')) as SymbolInfo;
 
       expect(isExtractError(docs)).toBe(false);
       expect(docs.name).toBe('add');
@@ -300,9 +298,7 @@ describe('TypeScript Extraction', () => {
     });
 
     it('should extract docs for a re-exported class', async () => {
-      const docs = (await extractDocs(
-        './test/fixtures/reexport-barrel:Counter',
-      )) as SymbolInfo;
+      const docs = (await extractDocs('./test/fixtures/reexport-barrel:Counter')) as SymbolInfo;
 
       expect(isExtractError(docs)).toBe(false);
       expect(docs.name).toBe('Counter');
@@ -321,9 +317,7 @@ describe('TypeScript Extraction', () => {
     });
 
     it('should extract docs for a re-exported enum', async () => {
-      const docs = (await extractDocs(
-        './test/fixtures/reexport-barrel:Status',
-      )) as SymbolInfo;
+      const docs = (await extractDocs('./test/fixtures/reexport-barrel:Status')) as SymbolInfo;
 
       expect(isExtractError(docs)).toBe(false);
       expect(docs.name).toBe('Status');
@@ -331,9 +325,7 @@ describe('TypeScript Extraction', () => {
     });
 
     it('should extract docs for a re-exported interface', async () => {
-      const docs = (await extractDocs(
-        './test/fixtures/reexport-barrel:Result',
-      )) as SymbolInfo;
+      const docs = (await extractDocs('./test/fixtures/reexport-barrel:Result')) as SymbolInfo;
 
       expect(isExtractError(docs)).toBe(false);
       expect(docs.name).toBe('Result');

--- a/test/resolution.test.ts
+++ b/test/resolution.test.ts
@@ -287,6 +287,69 @@ describe('TypeScript Extraction', () => {
     });
   });
 
+  describe('re-exported (aliased) symbols', () => {
+    it('should extract docs for a re-exported function', async () => {
+      const docs = (await extractDocs(
+        './test/fixtures/reexport-barrel:add',
+      )) as SymbolInfo;
+
+      expect(isExtractError(docs)).toBe(false);
+      expect(docs.name).toBe('add');
+      expect(docs.kind).toBe('function');
+      expect(docs.documentation).toContain('Adds two numbers');
+    });
+
+    it('should extract docs for a re-exported class', async () => {
+      const docs = (await extractDocs(
+        './test/fixtures/reexport-barrel:Counter',
+      )) as SymbolInfo;
+
+      expect(isExtractError(docs)).toBe(false);
+      expect(docs.name).toBe('Counter');
+      expect(docs.kind).toBe('class');
+      expect(docs.documentation).toContain('simple counter class');
+    });
+
+    it('should extract docs for a re-exported class instance member', async () => {
+      const docs = (await extractDocs(
+        './test/fixtures/reexport-barrel:Counter#increment',
+      )) as SymbolInfo;
+
+      expect(isExtractError(docs)).toBe(false);
+      expect(docs.name).toBe('Counter#increment');
+      expect(docs.kind).toBe('method');
+    });
+
+    it('should extract docs for a re-exported enum', async () => {
+      const docs = (await extractDocs(
+        './test/fixtures/reexport-barrel:Status',
+      )) as SymbolInfo;
+
+      expect(isExtractError(docs)).toBe(false);
+      expect(docs.name).toBe('Status');
+      expect(docs.kind).toBe('enum');
+    });
+
+    it('should extract docs for a re-exported interface', async () => {
+      const docs = (await extractDocs(
+        './test/fixtures/reexport-barrel:Result',
+      )) as SymbolInfo;
+
+      expect(isExtractError(docs)).toBe(false);
+      expect(docs.name).toBe('Result');
+      expect(docs.kind).toBe('interface');
+    });
+
+    it('should return SYMBOL_NOT_FOUND for non-existent re-export', async () => {
+      const docs = (await extractDocs(
+        './test/fixtures/reexport-barrel:NonExistent',
+      )) as ExtractError;
+
+      expect(isExtractError(docs)).toBe(true);
+      expect(docs.error.code).toBe('SYMBOL_NOT_FOUND');
+    });
+  });
+
   describe('getSourceLocation', () => {
     it('should resolve built-in module paths', async () => {
       const sourcePath = await getSourceLocation('typescript');


### PR DESCRIPTION
## Summary

- `extractDocs` fails for symbols that are re-exported through barrel files (e.g. `@reduxjs/toolkit:createSlice`, `@mui/material:Button`), even though `getSourceLocation` works fine for the same references.
- The root cause is that re-exported symbols have `SymbolFlags.Alias` and no direct `valueDeclaration`. The existing declaration-type checks in `extractDocs` don't account for this, causing the symbol to fall through to `findSymbolInJavaScriptFile` which fails on `.d.ts` files.
- Fix: resolve aliases via `checker.getAliasedSymbol()` before checking the declaration type. This recovers the original declaration and its full documentation.

This affects most of the npm ecosystem — any package using barrel re-exports (`export { X } from './X'`).

## Test plan

- Added test fixtures (`reexport-source.ts` + `reexport-barrel.ts`) with a barrel file that re-exports functions, classes, enums, and interfaces
- 6 new tests covering all re-exported symbol types and the error path
- Verified the 5 positive tests fail without the fix and pass with it
- Full test suite passes (134 tests)