### PR TITLE
Add Rsbuild/Rspack plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project supports:
 - Next.js 15/16
 - TanStack Start with React
 - Vite with React/Vue (which includes Astro, VitePress, etc)
+- Rsbuild/Rspack with React
 
 If you are using React/Vue with Django, FastAPI, Flask, Phoenix, or Rails,
 [follow the steps here instead](http://hexdocs.pm/tidewave/frontend.html).
@@ -253,10 +254,41 @@ be available. You can also use our
 [Supabase](https://hexdocs.pm/tidewave/supabase.html) integration for additional
 features.
 
+### Rsbuild / Rspack
+
+If you are using [Rsbuild](https://rsbuild.dev/) or
+[Rspack](https://rspack.dev/) as your build tool, install Tidewave with:
+
+```sh
+$ npm install -D tidewave
+# or
+$ yarn add -D tidewave
+# or
+$ pnpm add --save-dev tidewave
+# or
+$ bun add --dev tidewave
+```
+
+Then configure your `rsbuild.config.ts` (also works for `.js` and `.mjs`):
+
+```typescript
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import tidewave from 'tidewave/rsbuild-plugin';
+
+export default defineConfig({
+  plugins: [pluginReact(), tidewave()],
+});
+```
+
+Now make sure
+[Tidewave is installed](https://hexdocs.pm/tidewave/installation.html) and you
+are ready to connect Tidewave to your app.
+
 ### Configuration
 
-Next.js' `tidewaveHandler` and Vite's `tidewave` accept the configuration
-options below:
+Next.js' `tidewaveHandler`, Vite's `tidewave`, and Rsbuild's `tidewave` accept
+the configuration options below:
 
 - `allow_remote_access:` Tidewave only allows requests from localhost by
   default, even if your server listens on other interfaces, for security

--- a/bun.lock
+++ b/bun.lock
@@ -1,13 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "tidewave",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",
         "body-parser": "^2.2.0",
-        "chalk": "^5.3.0",
-        "commander": "^12.1.0",
         "connect": "^3.7.0",
         "typescript": "^5",
         "zod": "3.25.76",
@@ -26,6 +25,8 @@
         "@vercel/otel": "^2.0.1",
         "@vitest/ui": "^3.2.4",
         "bun-types": "latest",
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0",
         "eslint": "^9.16.0",
         "globals": "^15.14.0",
         "next": "^15.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidewave",
   "version": "0.6.0",
-  "description": "Tidewave for JavaScript (Next.js, TanStack, Vite)",
+  "description": "Tidewave for JavaScript (Next.js, TanStack, Vite, Rsbuild)",
   "keywords": [
     "typescript",
     "documentation",
@@ -10,7 +10,9 @@
     "tidewave",
     "next",
     "vite",
-    "tanstack"
+    "tanstack",
+    "rsbuild",
+    "rspack"
   ],
   "homepage": "https://tidewave.ai",
   "repository": {
@@ -52,6 +54,11 @@
       "import": "./dist/tanstack.js",
       "require": "./dist/tanstack.js"
     },
+    "./rsbuild-plugin": {
+      "types": "./dist/rsbuild-plugin.d.ts",
+      "import": "./dist/rsbuild-plugin.js",
+      "require": "./dist/rsbuild-plugin.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -62,7 +69,7 @@
   ],
   "scripts": {
     "dist": "bun run clean && bun run build:js && bun run build:types",
-    "build:js": "bun build --outdir dist --root src --external typescript --external child_process --external module --external @opentelemetry/api --external @opentelemetry/sdk-logs --external @opentelemetry/sdk-trace-base src/next-js/handler.ts src/next-js/instrumentation.ts src/vite-plugin.ts src/tanstack.ts src/evaluation/eval_worker.ts src/cli/index.ts --target node",
+    "build:js": "bun build --outdir dist --root src --external typescript --external child_process --external module --external @opentelemetry/api --external @opentelemetry/sdk-logs --external @opentelemetry/sdk-trace-base src/next-js/handler.ts src/next-js/instrumentation.ts src/vite-plugin.ts src/rsbuild-plugin.ts src/tanstack.ts src/evaluation/eval_worker.ts src/cli/index.ts --target node",
     "build:types": "tsc -p tsconfig.declarations.json",
     "dev": "bun run src/cli/index.ts",
     "test": "bun test",

--- a/src/rsbuild-plugin.ts
+++ b/src/rsbuild-plugin.ts
@@ -1,4 +1,5 @@
 import type { TidewaveConfig } from './core';
+import type { Server } from 'connect';
 import { configureServer } from './http';
 import { getProjectName } from './core';
 import { patchConsole } from './logger/console-patch';
@@ -10,40 +11,44 @@ const DEFAULT_CONFIG: TidewaveConfig = {
   allowRemoteAccess: false,
 } as const;
 
-export default function tidewave(config: TidewaveConfig = {}): {
+interface RsbuildPlugin {
   name: string;
   apply: 'serve';
-  setup: (api: any) => void;
-} {
+  setup: (api: {
+    modifyRsbuildConfig: (fn: (config: Record<string, Record<string, unknown>>) => void) => void;
+  }) => void;
+}
+
+interface Middlewares {
+  unshift: (...handlers: Server[]) => void;
+}
+
+export default function tidewave(config: TidewaveConfig = {}): RsbuildPlugin {
   return {
     name: 'rsbuild-plugin-tidewave',
     apply: 'serve',
-    setup(api) {
-      api.modifyRsbuildConfig((rsbuildConfig: any) => {
+    setup(api): void {
+      api.modifyRsbuildConfig(rsbuildConfig => {
         rsbuildConfig.dev ??= {};
 
         const existingSetup = rsbuildConfig.dev.setupMiddlewares;
 
         rsbuildConfig.dev.setupMiddlewares = [
-          ...(Array.isArray(existingSetup)
-            ? existingSetup
-            : existingSetup
-              ? [existingSetup]
-              : []),
+          ...(Array.isArray(existingSetup) ? existingSetup : existingSetup ? [existingSetup] : []),
 
-          (middlewares: { unshift: (...handlers: any[]) => void }) => {
+          (middlewares: Middlewares): void => {
             const app = connect();
             middlewares.unshift(app);
 
             // configureServer is sync — only getProjectName is async
             getProjectName('rsbuild_app').then(projectName => {
-              config = {
+              const resolvedConfig: TidewaveConfig = {
                 ...DEFAULT_CONFIG,
                 ...config,
                 framework: 'rsbuild',
                 projectName: config.projectName || projectName,
               };
-              configureServer(app, config);
+              configureServer(app, resolvedConfig);
             });
           },
         ];

--- a/src/rsbuild-plugin.ts
+++ b/src/rsbuild-plugin.ts
@@ -1,0 +1,53 @@
+import type { TidewaveConfig } from './core';
+import { configureServer } from './http';
+import { getProjectName } from './core';
+import { patchConsole } from './logger/console-patch';
+import connect from 'connect';
+
+patchConsole();
+
+const DEFAULT_CONFIG: TidewaveConfig = {
+  allowRemoteAccess: false,
+} as const;
+
+export default function tidewave(config: TidewaveConfig = {}): {
+  name: string;
+  apply: 'serve';
+  setup: (api: any) => void;
+} {
+  return {
+    name: 'rsbuild-plugin-tidewave',
+    apply: 'serve',
+    setup(api) {
+      api.modifyRsbuildConfig((rsbuildConfig: any) => {
+        rsbuildConfig.dev ??= {};
+
+        const existingSetup = rsbuildConfig.dev.setupMiddlewares;
+
+        rsbuildConfig.dev.setupMiddlewares = [
+          ...(Array.isArray(existingSetup)
+            ? existingSetup
+            : existingSetup
+              ? [existingSetup]
+              : []),
+
+          (middlewares: { unshift: (...handlers: any[]) => void }) => {
+            const app = connect();
+            middlewares.unshift(app);
+
+            // configureServer is sync — only getProjectName is async
+            getProjectName('rsbuild_app').then(projectName => {
+              config = {
+                ...DEFAULT_CONFIG,
+                ...config,
+                framework: 'rsbuild',
+                projectName: config.projectName || projectName,
+              };
+              configureServer(app, config);
+            });
+          },
+        ];
+      });
+    },
+  };
+}

--- a/test/rsbuild-plugin.test.ts
+++ b/test/rsbuild-plugin.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import tidewave from '../src/rsbuild-plugin';
+import type { TidewaveConfig } from '../src/core';
+
+// Mock the Rsbuild plugin API
+const createMockApi = () => {
+  const callbacks: ((config: any) => void)[] = [];
+
+  return {
+    modifyRsbuildConfig: (cb: (config: any) => void) => {
+      callbacks.push(cb);
+    },
+    _runCallbacks: (config: any) => {
+      for (const cb of callbacks) {
+        cb(config);
+      }
+    },
+  };
+};
+
+describe('Tidewave Rsbuild Plugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Plugin Creation', () => {
+    it('should create plugin with default config', () => {
+      const plugin = tidewave();
+
+      expect(plugin.name).toBe('rsbuild-plugin-tidewave');
+      expect(plugin.apply).toBe('serve');
+      expect(typeof plugin.setup).toBe('function');
+    });
+
+    it('should create plugin with custom config', () => {
+      const config: TidewaveConfig = {
+        allowRemoteAccess: true,
+      };
+
+      const plugin = tidewave(config);
+
+      expect(plugin.name).toBe('rsbuild-plugin-tidewave');
+      expect(plugin.apply).toBe('serve');
+    });
+
+    it('should handle empty config object', () => {
+      const plugin = tidewave({});
+
+      expect(plugin.name).toBe('rsbuild-plugin-tidewave');
+    });
+
+    it('should handle undefined config', () => {
+      const plugin = tidewave(undefined as any);
+
+      expect(plugin.name).toBe('rsbuild-plugin-tidewave');
+    });
+  });
+
+  describe('Plugin Interface Compliance', () => {
+    it('should return valid Rsbuild plugin object', () => {
+      const plugin = tidewave();
+
+      expect(plugin).toMatchObject({
+        name: expect.any(String),
+        apply: 'serve',
+        setup: expect.any(Function),
+      });
+    });
+
+    it('should only apply during dev server', () => {
+      const plugin = tidewave();
+
+      expect(plugin.apply).toBe('serve');
+    });
+
+    it('should have consistent plugin name', () => {
+      const plugin1 = tidewave();
+      const plugin2 = tidewave({ allowRemoteAccess: true });
+
+      expect(plugin1.name).toBe(plugin2.name);
+      expect(plugin1.name).toBe('rsbuild-plugin-tidewave');
+    });
+  });
+
+  describe('Setup and Middleware Registration', () => {
+    it('should register modifyRsbuildConfig callback', () => {
+      const plugin = tidewave();
+      const api = createMockApi();
+
+      plugin.setup(api);
+
+      const config: any = { dev: {} };
+      api._runCallbacks(config);
+
+      expect(config.dev.setupMiddlewares).toBeDefined();
+    });
+
+    it('should preserve existing setupMiddlewares (array)', () => {
+      const plugin = tidewave();
+      const api = createMockApi();
+      const existingMiddleware = vi.fn();
+
+      plugin.setup(api);
+
+      const config: any = { dev: { setupMiddlewares: [existingMiddleware] } };
+      api._runCallbacks(config);
+
+      expect(config.dev.setupMiddlewares).toHaveLength(2);
+      expect(config.dev.setupMiddlewares[0]).toBe(existingMiddleware);
+    });
+
+    it('should preserve existing setupMiddlewares (function)', () => {
+      const plugin = tidewave();
+      const api = createMockApi();
+      const existingMiddleware = vi.fn();
+
+      plugin.setup(api);
+
+      const config: any = { dev: { setupMiddlewares: existingMiddleware } };
+      api._runCallbacks(config);
+
+      expect(config.dev.setupMiddlewares).toHaveLength(2);
+      expect(config.dev.setupMiddlewares[0]).toBe(existingMiddleware);
+    });
+
+    it('should initialise dev config if missing', () => {
+      const plugin = tidewave();
+      const api = createMockApi();
+
+      plugin.setup(api);
+
+      const config: any = {};
+      api._runCallbacks(config);
+
+      expect(config.dev).toBeDefined();
+      expect(config.dev.setupMiddlewares).toBeDefined();
+    });
+
+    it('should add Connect app to middleware via unshift', () => {
+      const plugin = tidewave();
+      const api = createMockApi();
+
+      plugin.setup(api);
+
+      const config: any = { dev: {} };
+      api._runCallbacks(config);
+
+      const unshift = vi.fn();
+      const middlewares = { unshift };
+
+      // Run the setupMiddlewares callback
+      const tidewaveSetup = config.dev.setupMiddlewares[config.dev.setupMiddlewares.length - 1];
+      tidewaveSetup(middlewares);
+
+      // Should unshift a Connect app (which is a function)
+      expect(unshift).toHaveBeenCalledTimes(1);
+      expect(typeof unshift.mock.calls[0][0]).toBe('function');
+    });
+  });
+
+  describe('Configuration Validation', () => {
+    it('should accept valid allowRemoteAccess values', () => {
+      expect(() => tidewave({ allowRemoteAccess: true })).not.toThrow();
+      expect(() => tidewave({ allowRemoteAccess: false })).not.toThrow();
+    });
+
+    it('should accept combined configuration options', () => {
+      const config: TidewaveConfig = {
+        allowRemoteAccess: true,
+        projectName: 'my-app',
+      };
+
+      expect(() => tidewave(config)).not.toThrow();
+    });
+  });
+
+  describe('Default Export', () => {
+    it('should be a default export function', () => {
+      expect(typeof tidewave).toBe('function');
+    });
+  });
+});

--- a/test/rsbuild-plugin.test.ts
+++ b/test/rsbuild-plugin.test.ts
@@ -154,7 +154,7 @@ describe('Tidewave Rsbuild Plugin', () => {
 
       // Should unshift a Connect app (which is a function)
       expect(unshift).toHaveBeenCalledTimes(1);
-      expect(typeof unshift.mock.calls[0][0]).toBe('function');
+      expect(typeof unshift.mock.calls[0]?.[0]).toBe('function');
     });
   });
 


### PR DESCRIPTION
## Summary

- New entry point `tidewave/rsbuild-plugin` for projects using [Rsbuild](https://rsbuild.dev/) or [Rspack](https://rspack.dev/) as their build tool
- Follows the same pattern as the Vite plugin — patches console at module load, mounts Connect middleware via `setupMiddlewares`, and delegates to the shared HTTP layer
- Added `./rsbuild-plugin` to the package.json exports map and build script
- Added installation section to the README following the style of the existing framework sections
- Plugin uses `apply: 'serve'` to ensure it only runs during development

### Usage

```typescript
import { defineConfig } from '@rsbuild/core';
import { pluginReact } from '@rsbuild/plugin-react';
import tidewave from 'tidewave/rsbuild-plugin';

export default defineConfig({
  plugins: [pluginReact(), tidewave()],
});
```

## Test plan

- 15 new tests mirroring the Vite plugin test suite (plugin creation, interface compliance, middleware registration, config preservation, configuration validation)
- Tested against a real Rsbuild project (React 18 + Rspack) — all three endpoints (`/tidewave/`, `/tidewave/config`, `/tidewave/mcp`) respond correctly
- Full test suite passes (143 tests)